### PR TITLE
add user roles, license, update readme

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Anna Dolan, Erin Pintozzi, Nicholas Martinez, Noah Berman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
-# README
+# Ripped
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+An Exercism-like application for the Turing School of Software and Design.
 
-Things you may want to cover:
+### Installation
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+ - clone down this repo `git clone https://github.com/turingschool-projects/ripped`
+ - run `bundle install`
+ - we're using a custom version of a gem for staging, so also run: `bundle update`
+ - login is - at the moment - handled through [Census](https://github.com/turingschool-projects/census). as this is not yet in production you will probably need to stub out your users - we'll update as soon as this changes. You'll need Census access to run the app. 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,6 @@ class User < ApplicationRecord
   validates :census_id, presence: true
 
   has_many :solutions
+  
+  enum role: [:student, :instructor]
 end

--- a/db/migrate/20170207210329_add_role_to_users.rb
+++ b/db/migrate/20170207210329_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :role, :integer, default: 0  
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,16 @@
-ActiveRecord::Schema.define(version: 20170205172503) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20170207210329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,8 +49,9 @@ ActiveRecord::Schema.define(version: 20170205172503) do
 
   create_table "users", force: :cascade do |t|
     t.integer  "census_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "role",       default: 0
   end
 
   add_foreign_key "exercise_tags", "exercises"

--- a/spec/models/solution_status_spec.rb
+++ b/spec/models/solution_status_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Solution, type: :model do
     it "can have status Solved" do
       exercise = create(:exercise)
       solution = Solution.create(content: "solution name", exercise_id: exercise.id)
+      expect(solution.status).to eq("Submitted")
       solution.status = 1
       expect(solution.status).to eq("Solved")
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,4 +17,17 @@ RSpec.describe User, type: :model do
       expect(user).to respond_to(:solutions)
     end
   end
+  describe "roles" do
+    it { should define_enum_for(:role).with([:student, :instructor])}
+    it "is created with the role of student" do
+      user = create(:user)
+      expect(user.role).to eq("student")
+    end
+    it "can have the role of instructor" do
+      user = create(:user)
+      expect(user.role).to eq("student")
+      user.role = 1
+      expect(user.role).to eq("instructor")
+    end
+  end
 end


### PR DESCRIPTION
- closes the add user roles chore
- adds MIT license text
- adds boilerplate text to readme. since census access is required to use, it's basically just "download it, bundle, and then cross your fingers." programming! 🎉